### PR TITLE
Drupal 9 compatibility

### DIFF
--- a/elasticsearch_helper_preview.info.yml
+++ b/elasticsearch_helper_preview.info.yml
@@ -1,6 +1,7 @@
 name: Elasticsearch Helper Preview
 type: module
 description: Provide tools to preview content using Elasticsearch.
+core_version_requirement: ^8 || ^9
 core: 8.x
 package: ElasticSearch Helper
 configure: elasticsearch_helper_preview.settings


### PR DESCRIPTION
This PR adds Drupal 9 readiness for elasticsearch_helper_preview module.

Note:
Marking `core_version_requirement: ^8 || ^9 `as there is no deprecations introduced after 8.0.x

Checked with [Upgrade status](https://www.drupal.org/project/upgrade_status)