### PR TITLE
Edit the .info.yml file to allow the module to be installed in drupal10

### DIFF
--- a/elasticsearch_helper_preview.info.yml
+++ b/elasticsearch_helper_preview.info.yml
@@ -1,7 +1,7 @@
 name: Elasticsearch Helper Preview
 type: module
 description: Provide tools to preview content using Elasticsearch.
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8 || ^9 || 10
 core: 8.x
 package: ElasticSearch Helper
 configure: elasticsearch_helper_preview.settings


### PR DESCRIPTION
Checking the module using the `upgrade_status` reported this issue:

```

CONTRIBUTED PROJECTS
--------------------------------------------------------------------------------
Elasticsearch Helper Preview
Scanned on Thu, 01/26/2023 - 15:51.

1 warning found.

web/modules/contrib/elasticsearch_helper_preview/elasticsearch_helper_preview.in
fo.yml:
┌──────────┬──────┬────────────────────────────────────────────────────────────┐
│  STATUS  │ LINE │                          MESSAGE                           │
├──────────┼──────┼────────────────────────────────────────────────────────────┤
│ Check    │ 0    │ Value of core_version_requirement: ^8 || ^9 is not         │
│ manually │      │ compatible with the next major version of Drupal core. See │
│          │      │ https://drupal.org/node/3070687.                           │
│          │      │                                                            │
└──────────┴──────┴────────────────────────────────────────────────────────────┘

```

So this PRs fixes that by adding drupal 10 to the info.yml file.

After the fix, the scan does not find any issue: 

![image](https://user-images.githubusercontent.com/185412/215459574-fcb5ab09-1a32-4700-ae9e-1d35ba8df625.png)
